### PR TITLE
投稿タグ機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ gem 'mini_magick'
 gem 'haml-rails'
 gem 'kaminari'
 gem 'jquery-rails'
+gem "jquery-ui-rails"
+gem 'acts-as-taggable-on', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     archive-zip (0.12.0)
@@ -125,6 +127,8 @@ GEM
     jquery-turbolinks (2.1.0)
       railties (>= 3.1.0)
       turbolinks
+    jquery-ui-rails (6.0.1)
+      railties (>= 3.2.16)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -264,6 +268,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 6.0)
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
@@ -276,6 +281,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   jquery-turbolinks
+  jquery-ui-rails
   kaminari
   listen (>= 3.0.5, < 3.2)
   mini_magick

--- a/app/assets/stylesheets/modules/posts/_show.scss
+++ b/app/assets/stylesheets/modules/posts/_show.scss
@@ -5,6 +5,21 @@
   &__left{
     width: 65%;
     padding: 20px;
+    .show-post__content__tag{
+      height: 30px;
+      width: 860px;
+      display: flex;
+      line-height: 30px;
+      &--content{
+        height: 30px;
+        line-height: 30px;
+        padding: 0 10px;
+        margin-right: 14px;
+        display: inline-block;
+        border: solid 1px $title;
+        border-radius: 5px;
+      }
+    }
     .show-post__content__text{
       width: 860px;
       font-weight: lighter;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -54,7 +54,7 @@ class PostsController < ApplicationController
 
   private
   def post_params
-    params.require(:post).permit(:youtube_url, :text, :flyer).merge(artist_id: current_artist.id)
+    params.require(:post).permit(:youtube_url, :text, :tag_list).merge(artist_id: current_artist.id)
   end
 
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,7 +2,7 @@ class Post < ApplicationRecord
   belongs_to :artist
   has_many :favorites
   has_many :comments
-
+  acts_as_taggable
 
 
   def favorited_by?(listener)

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -22,6 +22,8 @@
                 = link_to "☆#{post.favorites.count}", post_favorites_path(post.id), method: :post
           - if artist_signed_in? && current_artist.id == post.artist_id
             .index-post__content--edit
+              - post.tag_list.each do |tag|
+                = tag 
               = link_to "編集", edit_post_path(post)
               = link_to "削除", post_path(post), method: :delete
           %br

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -22,8 +22,6 @@
                 = link_to "☆#{post.favorites.count}", post_favorites_path(post.id), method: :post
           - if artist_signed_in? && current_artist.id == post.artist_id
             .index-post__content--edit
-              - post.tag_list.each do |tag|
-                = tag 
               = link_to "編集", edit_post_path(post)
               = link_to "削除", post_path(post), method: :delete
           %br

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -9,6 +9,9 @@
         %br 
         = f.text_field :youtube_url, class: "post-field-input"
       .post-field
+        %label.post-field--title タグ
+        = f.text_field :tag_list, value: @post.tag_list.join(','), class: "post-field-input"
+      .post-field
         %label.post-field--title 投稿コメント
         %span.post-field--span 必須
         %br

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -2,6 +2,11 @@
   .show-content__left
     .show-post__content--youtube
       %iframe{:allow => "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture", :allowfullscreen => "", :frameborder => "0", :height => "615", :src => "https://www.youtube.com/embed/#{@post.youtube_url.last(11)}", :width => "860"}
+    .show-post__content__tag
+      タグ：
+      - @post.tag_list.each do |tag|
+        .show-post__content__tag--content
+          = tag
     .show-post__content__text
       .text-title
         Artist comment...
@@ -10,9 +15,12 @@
   .show-content__right
     .show-post__content__comment
       .show-post__content__comment--form
-        = form_with model:[@post,@comment], local: true do |f|
-          = f.text_field :comment, placeholder: "コメントする", class: "comment-input"
-          = f.submit "SEND", class: "comment-submit"
+        - if listener_signed_in?
+          = form_with model:[@post,@comment], local: true do |f|
+            = f.text_field :comment, placeholder: "コメントする", class: "comment-input"
+            = f.submit "SEND", class: "comment-submit"
+        - else
+          《 コメント一覧 》
       .show-post__content__comment--board
         - if @comments
           - @comments.each do |comment|

--- a/db/migrate/20200611235039_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200611235039_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,37 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20200611235040_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200611235040_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+    
+    # remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200611235041_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200611235041_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20200611235042_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200611235042_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200611235043_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200611235043_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20200611235044_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200611235044_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_11_133234) do
+ActiveRecord::Schema.define(version: 2020_06_11_235044) do
 
   create_table "artists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "artistname"
@@ -89,6 +89,33 @@ ActiveRecord::Schema.define(version: 2020_06_11_133234) do
     t.index ["listener_id"], name: "index_relationships_on_listener_id"
   end
 
+  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", collation: "utf8_bin"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   add_foreign_key "comments", "listeners"
   add_foreign_key "comments", "posts"
   add_foreign_key "favorites", "listeners"
@@ -98,4 +125,5 @@ ActiveRecord::Schema.define(version: 2020_06_11_133234) do
   add_foreign_key "posts", "artists"
   add_foreign_key "relationships", "listeners"
   add_foreign_key "relationships", "listeners", column: "follow_id"
+  add_foreign_key "taggings", "tags"
 end


### PR DESCRIPTION
## What
投稿へのタグ機能の実装
## Why
タグをつけることで投稿の区分けを可能とし、後にこのタグを含めた検索機能等も実装予定の為