### PR TITLE
各ページcss装飾

### DIFF
--- a/app/assets/stylesheets/modules/artist-show/_show.scss
+++ b/app/assets/stylesheets/modules/artist-show/_show.scss
@@ -98,12 +98,12 @@
         border-bottom: solid 1px darkgrey;
       }
       &__posts{
-        height: 70px;
         color: $text;
         margin: 10px;
-        position: relative;
         &--text{
           padding-top: 20px;
+          position: relative;
+          margin-bottom: 20px;
           a{
             color: $title;
             text-decoration: none;

--- a/app/assets/stylesheets/modules/posts/_index.scss
+++ b/app/assets/stylesheets/modules/posts/_index.scss
@@ -45,7 +45,7 @@
           width: 252px;
           object-fit: cover;
           vertical-align: top;
-          border-radius: 20px;
+          border-radius: 5px;
         }
         &--artistimage a {
           @include all-link-option ();
@@ -63,6 +63,13 @@
         }
         &--favorites{
           float: left;
+          color: $text;
+          a{
+            text-decoration: none;
+            color: $text;
+          }
+        }
+        &--edit{
           color: $text;
           a{
             text-decoration: none;

--- a/app/controllers/artistshow_controller.rb
+++ b/app/controllers/artistshow_controller.rb
@@ -1,6 +1,6 @@
 class ArtistshowController < ApplicationController
   def show
     @artist = Artist.find(params[:id])
-    @posts = @artist.posts.order("created_at DESC").page(params[:page]).per(1)
+    @posts = @artist.posts.order("created_at DESC").page(params[:page]).per(6)
   end
 end

--- a/app/views/artistshow/show.html.haml
+++ b/app/views/artistshow/show.html.haml
@@ -13,7 +13,7 @@
       - else
         = image_tag "/assets/default.png"
     %ul.artist-show__content__left__menulist
-      %li= link_to "アーティスト情報編集", edit_artist_registration_path, class: "artist-show__menulist--edit"
+      %li= link_to "アーティスト情報編集", edit_artist_registration_path, class: "artist-show__menulist--edit" unless @artist != current_artist || current_listener
       %li= "フォロワー数：#{@artist.followartists.count}"
       %li= "投稿数：#{@artist.posts.count}"
     - if listener_signed_in?


### PR DESCRIPTION
## What
各ページのCSS適応
## Why
トップページの投稿編集削除ボタンのデザインが統一感が無かったため
アーティスト編集ボタンが他のアーティスト、リスナーにも選択出来てしまった為自身のプロフィールのみ編集できるように修正