### PR TITLE
投稿コメントの折返し、はみ出し修正

### DIFF
--- a/app/assets/stylesheets/modules/posts/_show.scss
+++ b/app/assets/stylesheets/modules/posts/_show.scss
@@ -71,6 +71,8 @@
         height: 440px;
         margin-top: 10px;
         font-size: 15px;
+        overflow: scroll;
+        overflow-wrap: break-word;
         .board--nickname{
           color: $title;
         }


### PR DESCRIPTION
# 修正内容
- 投稿コメントの折返し表示修正
- 投稿コメントの下部はみ出し修正　→　スクロールできるように

# 修正理由
- コメントの可読性の低下防止、他の要素にコメントがかぶってしまうため修正は必須