### PR TITLE
ユーザー登録　placeholder設定

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
     kgio (2.11.3)
+    libv8 (3.16.14.19-x86_64-linux)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -251,6 +252,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    ref (2.0.0)
     regexp_parser (1.7.0)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -331,6 +333,9 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     temple (0.8.2)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -404,6 +409,7 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
+  therubyracer
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/views/artists/registrations/edit.html.haml
+++ b/app/views/artists/registrations/edit.html.haml
@@ -8,14 +8,14 @@
         %label.field--title アーティストネーム
         %span.field--span 必須
         %br/
-        = f.text_field :artistname, class: "field-input"
+        = f.text_field :artistname, placeholder: "アカウント名を入力してください", class: "field-input"
         - if resource.errors.include?(:artistname)
           %p.field-error= resource.errors.full_messages_for(:artistname).first
       .field
         %label.field--title メールアドレス
         %span.field--span 必須
         %br/
-        = f.email_field :email, autocomplete: "email", class: "field-input"
+        = f.email_field :email, placeholder: "メールアドレスを入力してください", autocomplete: "email", class: "field-input"
         - if resource.errors.include?(:email)
           %p.field-error= resource.errors.full_messages_for(:email).first
       .field
@@ -28,7 +28,7 @@
       .field
         %label.field--title プロフィール
         %br/
-        = f.text_area :profile, class: "field-input"
+        = f.text_area :profile, placeholder: "プロフィール入力欄", class: "field-input"
       .field
         %label.field--imagetitle アーティスト写真
         %br/

--- a/app/views/artists/registrations/new.html.haml
+++ b/app/views/artists/registrations/new.html.haml
@@ -7,21 +7,21 @@
         %label.field--title アーティストネーム
         %span.field--span 必須
         %br/
-        = f.text_field :artistname, class: "field-input"
+        = f.text_field :artistname, placeholder: "アカウント名を入力してください", class: "field-input"
         - if resource.errors.include?(:artistname)
           %p.field-error= resource.errors.full_messages_for(:artistname).first
       .field
         %label.field--title メールアドレス
         %span.field--span 必須
         %br/
-        = f.email_field :email, autocomplete: "email", class: "field-input"
+        = f.email_field :email, placeholder: "メールアドレスを入力してください", autocomplete: "email", class: "field-input"
         - if resource.errors.include?(:email)
           %p.field-error= resource.errors.full_messages_for(:email).first
       .field
         %label.field--title パスワード
         %span.field--span 必須
         %br/
-        = f.password_field :password, autocomplete: "new-password", class: "field-input"
+        = f.password_field :password, placeholder: "英字数含む７文字以上", autocomplete: "new-password", class: "field-input"
         - if resource.errors.include?(:password)
           %p.field-error= resource.errors.full_messages_for(:password).first
       .field

--- a/app/views/listeners/registrations/edit.html.haml
+++ b/app/views/listeners/registrations/edit.html.haml
@@ -5,20 +5,20 @@
     = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "user__form", method: :put }) do |f|
       = render "devise/shared/error_messages", resource: resource
       .field
-        %label.field--title ニックネーム
+        %label.field--title ユーザーネーム
         %span.field--span 必須
         %br/
-        = f.text_field :nickname, class: "field-input"
+        = f.text_field :nickname, placeholder: "アカウント名を入力してください", class: "field-input"
       .field
         %label.field--title メールアドレス
         %span.field--span 必須
         %br/
-        = f.email_field :email, autocomplete: "email", class: "field-input"
+        = f.email_field :email, placeholder: "メールアドレスを入力してください", autocomplete: "email", class: "field-input"
       .field
         %label.field--title パスワード
         %span.field--span 必須
         %br/
-        = f.password_field :current_password, autocomplete: "current-password", class: "field-input"
+        = f.password_field :current_password, placeholder: "現在のパスワード", autocomplete: "current-password", class: "field-input"
         %br
         ※現在のパスワードを入力してください。
       .actions

--- a/app/views/listeners/registrations/new.html.haml
+++ b/app/views/listeners/registrations/new.html.haml
@@ -7,21 +7,21 @@
         %label.field--title ユーザーネーム
         %span.field--span 必須
         %br/
-        = f.text_field :nickname, class: "field-input"
+        = f.text_field :nickname, placeholder: "アカウント名を入力してください", class: "field-input"
         - if resource.errors.include?(:nickname)
           %p.field-error= resource.errors.full_messages_for(:nickname).first
       .field
         %label.field--title メールアドレス
         %span.field--span 必須
         %br/
-        = f.email_field :email, autocomplete: "email", class: "field-input"
+        = f.email_field :email, placeholder: "メールアドレスを入力してください", autocomplete: "email", class: "field-input"
         - if resource.errors.include?(:email)
           %p.field-error= resource.errors.full_messages_for(:email).first
       .field
         %label.field--title パスワード
         %span.field--span 必須
         %br/
-        = f.password_field :password, autocomplete: "new-password", class: "field-input"
+        = f.password_field :password, placeholder: "英字数含む７文字以上", autocomplete: "new-password", class: "field-input"
         - if resource.errors.include?(:password)
           %p.field-error= resource.errors.full_messages_for(:password).first
       .field


### PR DESCRIPTION
# 修正内容
- 新規登録項目フォーム内になにを入力すればよいかの案内を表示

# 修正理由
- 案内を表示することでユーザーが機能を把握しやすくなると思われるため